### PR TITLE
Added network-independent DNS 8.8.8.8 to rl.yml to avoid name resolution failure

### DIFF
--- a/conf/development.yml
+++ b/conf/development.yml
@@ -16,6 +16,8 @@ services:
     network_mode: "host"
     security_opt:
       - apparmor:unconfined
+    dns:
+      - 8.8.8.8
 
 devenv:
   version: '1.0'

--- a/conf/rl.yml
+++ b/conf/rl.yml
@@ -16,6 +16,8 @@ services:
     network_mode: "host"
     security_opt:
       - apparmor:unconfined
+    dns:
+      - 8.8.8.8
 
 devenv:
   version: '1.0'

--- a/conf/tools.yml
+++ b/conf/tools.yml
@@ -11,6 +11,8 @@ services:
       - 8888:8888
     stdin_open: true
     tty: true
+    dns:
+      - 8.8.8.8
 
 devenv:
   version: '1.0'


### PR DESCRIPTION
Name resolution from within the Docker container might have failed when the host machine switched network: 

```bash
rlpyt on  master via 🐍 v3.6.9 (ve) 
❯ ping 8.8.8.8
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=55 time=24.0 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=55 time=21.9 ms
64 bytes from 8.8.8.8: icmp_seq=3 ttl=55 time=24.9 ms
64 bytes from 8.8.8.8: icmp_seq=4 ttl=55 time=22.5 ms
64 bytes from 8.8.8.8: icmp_seq=5 ttl=55 time=26.0 ms
64 bytes from 8.8.8.8: icmp_seq=6 ttl=55 time=21.5 ms
64 bytes from 8.8.8.8: icmp_seq=7 ttl=55 time=23.2 ms
64 bytes from 8.8.8.8: icmp_seq=8 ttl=55 time=23.8 ms

--- 8.8.8.8 ping statistics ---
8 packets transmitted, 8 received, 0% packet loss, time 7008ms
rtt min/avg/max/mdev = 21.551/23.536/26.055/1.427 ms

rlpyt on  master via 🐍 v3.6.9 (ve) 
❯ ping http://www.google.it
ping: http://www.google.it: Temporary failure in name resolution
```

The container would then have to be stopped and restarted in order for name resolution to work again.

By adding a `dns` key with a fixed DNS address (in this case, the Google DNS 8.8.8.8), the problem is fixed.